### PR TITLE
Add job-build.yaml for azure pipelines image build/push

### DIFF
--- a/.pipelines/job-build.yaml
+++ b/.pipelines/job-build.yaml
@@ -1,0 +1,62 @@
+parameters:
+  name: ''
+  pool: ''
+  goPath: ''
+  goAppName: ''
+  prodRegistry: ''
+  registryUsername: ''
+  registryPassword: ''
+  imagePrefix: ''
+  mutableVersion: ''
+
+jobs:
+  - job: ${{ parameters.name }}
+    pool: ${{ parameters.pool }}
+    steps:
+    - task: GoTool@0
+      displayName: Use Go 1.13
+      inputs:
+        version: '1.13.3'
+        goPath: ${{ parameters.goPath }}
+
+    - script: echo "##vso[task.setvariable variable=path;isOutput=true]$PATH"
+      name: existingpath
+
+    - bash: |
+        export PATH="$GOPATH/bin:$PATH"
+        mkdir -p $APP_PATH
+        cp -Rp "$SYSTEM_DEFAULTWORKINGDIRECTORY/." $APP_PATH
+      displayName: put code in gopath
+      env:
+        APP_PATH: ${{ format('{0}/src/{1}', parameters.goPath, parameters.goAppName) }}
+
+    - script: 'git config --global --add http.https://msazure.visualstudio.com.extraheader "AUTHORIZATION: bearer $SYSTEM_ACCESSTOKEN"'
+      displayName: configure git
+      workingDirectory: ${{ format('{0}/src/{1}', parameters.goPath, parameters.goAppName) }}
+      env:
+        SYSTEM_ACCESSTOKEN: $(system.accesstoken)
+
+    - bash: |
+        echo "IMG: $IMG"
+        go mod tidy
+        make docker-ci
+      displayName: docker build and push
+      workingDirectory: ${{ format('{0}/src/{1}', parameters.goPath, parameters.goAppName) }}
+      env:
+        REGISTRY: ${{ parameters.prodRegistry }}
+        REGISTRY_USERNAME: ${{ parameters.registryUsername }}
+        REGISTRY_PASSWORD: ${{ parameters.registryPassword }}
+        IMG: ${{ format('{0}/{1}/ctrlarm:{2}', parameters.prodRegistry, parameters.imagePrefix, parameters.mutableVersion) }}
+
+    - task: CopyFiles@2
+      displayName: stage artifacts
+      inputs:
+        sourceFolder: ${{ format('{0}/src/{1}', parameters.goPath, parameters.goAppName) }}
+        contents:  'out/**'
+        targetFolder: '$(Build.ArtifactStagingDirectory)'
+
+    - task: PublishBuildArtifacts@1
+      displayName: save artifacts
+      inputs:
+        pathtoPublish: '$(Build.ArtifactStagingDirectory)' 
+        artifactName: 'drop' 

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,12 @@ docker-build: test
 docker-push:
 	docker push ${IMG}
 
+docker-ci: generate fmt manifests
+	go build -o bin/manager main.go
+	docker login ${REGISTRY} -u ${REGISTRY_USERNAME} -p ${REGISTRY_PASSWORD}
+	docker build . -t ${IMG}
+	docker push ${IMG}
+
 # find or download controller-gen
 # download controller-gen if necessary
 controller-gen:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -1,0 +1,33 @@
+name: 1.0.$(Date:yyyyMMdd)$(Rev:rr)
+
+trigger:
+  batch: true
+  branches:
+    include: 
+    - master
+  paths:
+    exclude:
+    - 'README.md'
+    - 'docs'
+    - 'azure-pipelines.yaml'
+
+variables:
+  - name: 'goPath'
+    value: '$(Agent.HomeDirectory)/go'
+  - name:   'goAppName'
+    value: 'github.com/juan-lee/ctrlarm'
+  - group: 'aks-prod-registry'
+
+jobs:
+- template: '.pipelines/job-build.yaml'
+  parameters:
+    name: 'build_validator'
+    pool:
+      vmImage: 'ubuntu-16.04'
+    goPath: $(goPath)
+    goAppName: $(goAppName)
+    imagePrefix: $(IMAGE_PREFIX)
+    prodRegistry: $(PROD_REGISTRY)
+    registryUsername: $(REGISTRY_USERNAME)
+    registryPassword: $(REGISTRY_PASSWORD)
+    mutableVersion: $(MUTABLE_VERSION)


### PR DESCRIPTION
This PR adds an azure pipelines job config to build the binary, docker image, and push to a registry. It also adds a new make stage called `docker-ci`, which is basically the same as `make manager` and docker build/push, but excluding the lint stage which requires a dependency on `golangci`.