### PR TITLE
Adding support for setting NodePoolType

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -39,4 +39,7 @@ type NodePool struct {
 
 	// Capacity is the number of VMs in a node pool.
 	Capacity int32 `json:"capacity,omitempty"`
+
+	// AgentPoolType sets what kind of agent pool is used for this node pool (e.g. "VirtualMachineScaleSets").
+	NodePoolType string `json:"nodePoolType,omitempty"`
 }

--- a/config/crd/bases/azure.jpang.dev_managedclusters.yaml
+++ b/config/crd/bases/azure.jpang.dev_managedclusters.yaml
@@ -85,6 +85,10 @@ spec:
                   name:
                     description: Name of the node pool.
                     type: string
+                  nodePoolType:
+                    description: AgentPoolType sets what kind of agent pool is used
+                      for this node pool (e.g. "VirtualMachineScaleSets").
+                    type: string
                   sku:
                     description: SKU of the VMs in the node pool.
                     type: string

--- a/controllers/managedcluster_controller.go
+++ b/controllers/managedcluster_controller.go
@@ -373,6 +373,7 @@ func makeAgentPoolProfiles(nodePools []azurev1.NodePool) *[]containerservice.Man
 			Name:   &np.Name,
 			Count:  &np.Capacity,
 			VMSize: containerservice.VMSizeTypes(np.SKU),
+			Type:   containerservice.AgentPoolType(np.NodePoolType),
 		})
 	}
 	return &result


### PR DESCRIPTION
We needed to be able create clusters with a type of `VirtualMachineScaleSets`. This PR allows us to do that.